### PR TITLE
Fixed examples / Help with my error?

### DIFF
--- a/examples/receive.rs
+++ b/examples/receive.rs
@@ -1,15 +1,20 @@
 #![allow(dead_code)]
-use galaxy_buds_live_rs::message::{self, ids, Message};
+use galaxy_buds_rs::{
+    message::{self, ids, Message},
+    model::Model,
+};
 
 use async_std::io::prelude::*;
 use bluetooth_serial_port_async::{BtAddr, BtProtocol, BtSocket};
-use std::{error::Error, str::FromStr};
+use std::{env, error::Error, str::FromStr};
 
 async fn run() -> Result<(), Box<dyn Error>> {
-    let address = "<Your Buds address here!!>";
+    let address = env::args().nth(1).unwrap();
 
     let mut socket = BtSocket::new(BtProtocol::RFCOMM).unwrap();
-    socket.connect(&BtAddr::from_str(address).unwrap()).unwrap();
+    socket
+        .connect(BtAddr::from_str(address.as_ref()).unwrap())
+        .unwrap();
 
     // Get the stream of the socket. Only call this function
     // once and keep using the stream
@@ -21,7 +26,8 @@ async fn run() -> Result<(), Box<dyn Error>> {
         let buff = &buffer[0..num_bytes_read];
 
         let id = buff[3].to_be();
-        let message = Message::new(buff);
+        let message = Message::new(buff, Model::Buds);
+        println!("{:?}", buff);
 
         if id == 242 {
             continue;

--- a/examples/send.rs
+++ b/examples/send.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code)]
-use galaxy_buds_live_rs::message::{self, bud_property::EqualizerType, Payload}; // Note: Import 'Payload' to be able to convert the message to bytes
+use galaxy_buds_rs::message::{self, bud_property::EqualizerType, Payload}; // Note: Import 'Payload' to be able to convert the message to bytes
 
 use async_std::io::prelude::*;
 use bluetooth_serial_port_async::{BtAddr, BtProtocol, BtSocket}; /* https://crates.io/crates/bluetooth-serial-port-async */
-use std::{error::Error, str::FromStr};
+use std::{env, error::Error, str::FromStr};
 
 async fn run() -> Result<(), Box<dyn Error>> {
-    let address = "<Your Buds address here!!>";
+    let address = env::args().nth(1).unwrap();
 
-    let mut socket = BtSocket::new(BtProtocol::RFCOMM).unwrap();
-    socket.connect(&BtAddr::from_str(address).unwrap()).unwrap();
+    let mut socket = BtSocket::new(BtProtocol::RFCOMM).expect("RFCOMM");
+    socket
+        .connect(BtAddr::from_str(address.as_ref()).expect("Address"))
+        .expect("Socket not connecting");
 
     // Get the stream of the socket. Only call this function
     // once and keep using the stream


### PR DESCRIPTION
- [x] Fixed examples
- [x] Can't connect to my device...

```
> bt-device -l
Added devices:
Galaxy Buds (33F9) (D8:55:75:7A:33:F9)
```

```
> cargo run --example receive D8:55:75:7A:33:F9

warning: only one of `license` or `license-file` is necessary
   Compiling galaxy_buds_rs v0.2.7 (/home/mitch/GalaxyBuds-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 1.23s
     Running `target/debug/examples/receive 'D8:55:75:7A:33:F9'`
"D8:55:75:7A:33:F9"
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Desc("No RFCOMM service on remote device")', examples/receive.rs:15:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```