### PR TITLE
feat: add buds pro 2 support

### DIFF
--- a/src/message/debug.rs
+++ b/src/message/debug.rs
@@ -83,6 +83,10 @@ impl GetAllData {
             return None;
         }
 
+        if model == Model::BudsPro2 {
+            return None;
+        }
+
         let mut data;
         if model == Model::Buds2 {
             data = Self {

--- a/src/message/extended_status_updated.rs
+++ b/src/message/extended_status_updated.rs
@@ -158,6 +158,43 @@ pub fn new(arr: &[u8], model: Model) -> ExtendedStatusUpdate {
             tap_lock_status: ExtTapLockStatus::default(),
         },
 
+        Model::BudsPro2 => ExtendedStatusUpdate {
+            revision: buff.get(0),
+            ear_type: buff.get(1),
+            battery_left: buff.get(2) as i8,
+            battery_right: buff.get(3) as i8,
+            coupled: buff.get_bool(4),
+            primary_earbud: Side::from(buff.get_bool(5)),
+            placement_left,
+            placement_right,
+            wearing_left: placement_left == Placement::Ear,
+            wearing_right: placement_right == Placement::Ear,
+            battery_case: buff.get(7) as i8,
+            adjust_sound_sync: buff.get_bool(8),
+            equalizer_type: EqualizerType::decode(buff.get(9)),
+            touchpads_blocked: buff.get_bool(10),
+            touchpad_option_left: TouchpadOption::value(buff.get(11), Side::Left),
+            touchpad_option_right: TouchpadOption::value(buff.get(11), Side::Right),
+            noise_reduction: buff.get_bool(12),
+            voice_wake_up: buff.get_bool(13),
+            color_left: buff.get_short(14),
+            color_right: buff.get_short(16),
+            ambient_sound_volume: buff.get(23) as i32,
+            ambient_sound_enabled: false,
+            ambient_mode: AmbientType::Normal,
+            extra_high_ambient: {
+                if buff.get(0) < 3 {
+                    buff.get_bool(22)
+                } else if buff.get(0) >= 6 {
+                    buff.get_bool(30)
+                } else {
+                    false
+                }
+            },
+            outside_double_tap: false,
+            tap_lock_status: ExtTapLockStatus::default(),
+        },
+
         Model::Buds2 => ExtendedStatusUpdate {
             revision: buff.get(0),
             ear_type: buff.get(1),

--- a/src/model.rs
+++ b/src/model.rs
@@ -7,6 +7,7 @@ pub enum Model {
     BudsPlus,
     BudsLive,
     BudsPro,
+    BudsPro2,
     Buds2,
 }
 
@@ -68,6 +69,11 @@ impl Model {
                 vec![Feature::Anc, Feature::VoiceWakeup, Feature::AdjustSoundSync]
             }
 
+
+            Model::BudsPro2 => {
+                vec![Feature::Anc, Feature::VoiceWakeup, Feature::AdjustSoundSync]
+            }
+
             Model::Buds2 => {
                 vec![
                     Feature::Anc,
@@ -86,6 +92,7 @@ impl Model {
             Model::BudsPlus => "Galaxy Buds+",
             Model::BudsLive => "Galaxy Buds Live",
             Model::BudsPro => "Galaxy Buds Pro",
+            Model::BudsPro2 => "Galaxy Buds Pro 2",
             Model::Buds2 => "Galaxy Buds 2",
         }
     }


### PR DESCRIPTION
add support to buds pro 2

I test using [LiveBudsCli](https://github.com/JojiiOfficial/LiveBudsCli) and I can handle basic functions

```
➜  debug git:(master) ✗ ./earbuds status -v
Info for 'George's Buds2 Pro':

Type:		Buds2
Battery:	L: 87%, R: 87%
Equalizer:	Normal
ANC:		Enabled
Touchpads:	Tap, Tap and hold
Left option:	NoiseCanceling
Right option:	NoiseCanceling
Temp. left:	36.0°C
Temp. right:	37.0°C
Current left:	0.0mA
Current right:	0.0mA
Volt left:	0.0V
Volt right:	0.0V
➜  debug git:(master) ✗ ./earbuds set anc false
Success
➜  debug git:(master) ✗ ./earbuds set ambientsound 0
Success
```