### PR TITLE
Add noise control update message

### DIFF
--- a/src/message/bud_property.rs
+++ b/src/message/bud_property.rs
@@ -193,3 +193,31 @@ impl BudProperty for AmbientType {
         }
     }
 }
+
+/// NoiseControlMode
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum NoiseControlMode {
+    Off,
+    NoiseReduction,
+    AmbientSound,
+}
+
+impl BudProperty for NoiseControlMode {
+    type Item = NoiseControlMode;
+
+    fn decode(val: u8) -> NoiseControlMode {
+        match val {
+            1 => NoiseControlMode::NoiseReduction,
+            2 => NoiseControlMode::AmbientSound,
+            _ => NoiseControlMode::Off,
+        }
+    }
+
+    fn encode(&self) -> u8 {
+        match *self {
+            NoiseControlMode::Off => 0,
+            NoiseControlMode::NoiseReduction => 1,
+            NoiseControlMode::AmbientSound => 2,
+        }
+    }
+}

--- a/src/message/ids.rs
+++ b/src/message/ids.rs
@@ -33,6 +33,7 @@ pub const MANAGER_INFO: u8 = 136;
 pub const MSG_ID_OUTSIDE_DOUBLE_TAP: u8 = 149;
 pub const MUTE_EARBUD: u8 = 162;
 pub const MUTE_EARBUD_STATUS_UPDATED: u8 = 163;
+pub const NOISE_CONTROLS_UPDATE: u8 = 119;
 pub const NOISE_REDUCTION_MODE_UPDATE: u8 = 155;
 pub const PASS_THROUGH: u8 = 159;
 pub const RESET: u8 = 80;

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -11,6 +11,7 @@ pub mod ids;
 pub mod lock_touchpad;
 pub mod manager;
 pub mod mute_earbud;
+pub mod noise_controls_updated;
 pub mod response;
 pub mod set_noise_reduction;
 pub mod set_touchpad_option;

--- a/src/message/noise_controls_updated.rs
+++ b/src/message/noise_controls_updated.rs
@@ -1,0 +1,36 @@
+use super::bud_property::{BudProperty, NoiseControlMode, Placement, Side};
+use super::{ids, Payload};
+
+// Whether the buds changed the noise control status by a touchpad event
+#[derive(Debug, Clone, Copy)]
+pub struct NoiseControlsUpdated {
+    pub noise_control_mode: NoiseControlMode,
+    pub placement_left: Placement,
+    pub placement_right: Placement,
+}
+
+impl NoiseControlsUpdated {
+    pub fn new(arr: &[u8]) -> Self {
+        let placement_left = Placement::value(arr[1], Side::Left);
+        let placement_right = Placement::value(arr[1], Side::Right);
+
+        Self {
+            noise_control_mode: NoiseControlMode::decode(arr[0]),
+            placement_left,
+            placement_right,
+        }
+    }
+}
+
+impl Payload for NoiseControlsUpdated {
+    fn get_id(&self) -> u8 {
+        ids::NOISE_CONTROLS_UPDATE
+    }
+}
+
+// Allow parsing Message to a StatusUpdate
+impl Into<NoiseControlsUpdated> for super::Message {
+    fn into(self) -> NoiseControlsUpdated {
+        NoiseControlsUpdated::new(self.get_payload_bytes())
+    }
+}


### PR DESCRIPTION
Add a message that exists at least in the Buds 2, for changing the noise control status.